### PR TITLE
Upload signed and aligned apk instead of unaligned version

### DIFF
--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppPlugin.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppPlugin.groovy
@@ -53,7 +53,7 @@ class HockeyAppPlugin implements Plugin<Project> {
                 HockeyAppUploadTask task = project.tasks.create("upload${variant.name}ToHockeyApp", HockeyAppUploadTask)
                 task.group = 'HockeyApp'
                 task.description = "Upload '${variant.name}' to HockeyApp"
-                task.applicationApk = variant.packageApplication.outputFile
+                task.applicationApk = variant.outputFile
                 task.outputs.upToDateWhen { false }
 
                 task.dependsOn variant.assemble


### PR DESCRIPTION
The ApplicationVariant property `packageApplication.outputFile` contains the file name of the unaligned apk. However, the signed apk should be uploaded to HockeyApp, which is available in `outputFile`
