### PR TITLE
Build type should be capitalized in task name

### DIFF
--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppPlugin.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppPlugin.groovy
@@ -50,7 +50,7 @@ class HockeyAppPlugin implements Plugin<Project> {
             AppExtension android = project.android
             android.applicationVariants.all { ApplicationVariant variant ->
 
-                HockeyAppUploadTask task = project.tasks.create("upload${variant.name}ToHockeyApp", HockeyAppUploadTask)
+                HockeyAppUploadTask task = project.tasks.create("upload${variant.name.capitalize()}ToHockeyApp", HockeyAppUploadTask)
                 task.group = 'HockeyApp'
                 task.description = "Upload '${variant.name}' to HockeyApp"
                 task.applicationApk = variant.outputFile


### PR DESCRIPTION
Variant name in task name should be capitalized so you can for example use `gradle URTHA` instead of `gradle uploadreleaseToHockeyApp`.
