### PR TITLE
Removed "configureDependencies" method from plugin.

### DIFF
--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppPlugin.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppPlugin.groovy
@@ -33,7 +33,6 @@ import com.android.build.gradle.AppPlugin
 class HockeyAppPlugin implements Plugin<Project> {
 
     void apply(Project project) {
-        configureDependencies(project)
         applyExtensions(project)
         applyTasks(project)
     }
@@ -69,13 +68,6 @@ class HockeyAppPlugin implements Plugin<Project> {
 
                 task.dependsOn variant.assemble
             }
-        }
-    }
-
-
-    void configureDependencies(final Project project) {
-        project.repositories {
-            mavenCentral()
         }
     }
 


### PR DESCRIPTION
Right now, when a target project uses this plugin, it force-sets the incoming project's dependencies to mavenCental(), which overrides any custom maven repository configured for that project. This change will ensure that the target project is solely responsible for declaring where the you would like to retrieve their dependencies outside of just mavenCentral(). Fixes #31.
