### PR TITLE
Change default symbols directory

### DIFF
--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppPlugin.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppPlugin.groovy
@@ -60,7 +60,7 @@ class HockeyAppPlugin implements Plugin<Project> {
                     if (variant.getFlavorName().length() > 0) {
                         flavorFilePart = "${variant.getFlavorName()}/"
                     }
-                    symbolsDirectory = new File(project.buildDir, "proguard/${flavorFilePart}${variant.getBuildType().getName()}")
+                    symbolsDirectory = new File(project.buildDir, "outputs/proguard/${flavorFilePart}${variant.getBuildType().getName()}")
                 }
                 task.symbolsDirectory = symbolsDirectory
                 task.variantName = variant.name


### PR DESCRIPTION
The default symbols directory was wrong and therefor not finding the mapping.txt file. This fix just changes the  default location to be inside the outputs directory.
