### PR TITLE
add support for variantToStatus, mandatory and variantToMandatory

### DIFF
--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppPluginExtension.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppPluginExtension.groovy
@@ -44,6 +44,10 @@ class HockeyAppPluginExtension {
     def int timeout = 60 * 1000
     def Map<String, String> variantToApplicationId = null
     def Boolean teamCityLog = false
+    def Map<String, String> variantToStatus = null
+    def String mandatory = 0
+    def Map<String, String> variantToMandatory = null
+
 
     private final Project project
 

--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
@@ -158,7 +158,7 @@ class HockeyAppUploadTask extends DefaultTask {
                     }
                 }
             }
-            
+
         }
 
         httpPost.setEntity(new ProgressHttpEntityWrapper(entityBuilder.build(), progressCallback));
@@ -208,8 +208,14 @@ class HockeyAppUploadTask extends DefaultTask {
         if (project.hockeyapp.notes) {
             entityBuilder.addPart("notes", new StringBody(project.hockeyapp.notes))
         }
-        if (project.hockeyapp.status) {
-            entityBuilder.addPart("status", new StringBody(project.hockeyapp.status))
+        String status = project.hockeyapp.status
+        if (project.hockeyapp.variantToStatus != null) {
+            if (project.hockeyapp.variantToStatus[variantName]){
+              status = project.hockeyapp.variantToStatus[variantName]
+            }
+        }
+        if (status) {
+            entityBuilder.addPart("status", new StringBody(status))
         }
         if (project.hockeyapp.releaseType) {
             entityBuilder.addPart("release_type", new StringBody(project.hockeyapp.releaseType))
@@ -225,6 +231,15 @@ class HockeyAppUploadTask extends DefaultTask {
         }
         if (project.hockeyapp.tags) {
             entityBuilder.addPart("tags", new StringBody(project.hockeyapp.tags))
+        }
+        String mandatory = project.hockeyapp.mandatory
+        if (project.hockeyapp.variantToMandatory != null){
+            if (project.hockeyapp.variantToMandatory[variantName]){
+              mandatory = project.hockeyapp.variantToMandatory[variantName]
+            }
+        }
+        if (mandatory){
+            entityBuilder.addPart("mandatory", new StringBody(mandatory))
         }
     }
 


### PR DESCRIPTION
There are situations when you upload multiple version to hockey app and some of them should be downloadable and others not. So I created a variantToStatus map to set the status for each variant.
This is the logic: if the status is set in variantToStatus use that one, otherwise use the one from status if present.

I also added support in similar way for the mandatory property.
