### PR TITLE
add variantToApiToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gradle-hockeyapp-plugin [![Build Status](https://travis-ci.org/x2on/gradle-hockeyapp-plugin.png)](https://travis-ci.org/x2on/gradle-hockeyapp-plugin) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/de.felixschulze.gradle/gradle-hockeyapp-plugin/badge.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22de.felixschulze.gradle%22%20AND%20a%3A%22gradle-hockeyapp-plugin%22) [![License MIT](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/x2on/gradle-hockeyapp-plugin/blob/master/LICENSE)
 
-A Gradle plugin for uploading iOS and Android Apps to HockeyApp. 
+A Gradle plugin for uploading iOS and Android Apps to HockeyApp.
 
 ## Basic usage
 
@@ -45,6 +45,7 @@ hockeyapp {
 * `apiToken`: Your API Token from [HockeyApp](http://hockeyapp.net/)
 
 ### Optional
+* `variantToApiToken`: Optional: `[variantName: "YOURHOCKEYAPPTOKEN", variantName2: "YOUROTHERHOCKEYAPPTOKEN"]` map between your variants and api tokens
 * `releaseType`: `0` beta, `1` live, `2` alpha
 * `variantToReleaseType`: Optional: `[variantName: "0", variantName2: "1"]` map between your variants and releaseType
 * `notify`: `0` not notify testers, `1` notify all testers that can install this app

--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppPluginExtension.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppPluginExtension.groovy
@@ -30,6 +30,7 @@ class HockeyAppPluginExtension {
     def Object outputDirectory
     def File symbolsDirectory = null
     def String apiToken = null
+    def Map<String, String> variantToApiToken = null
     def String notes = "This build was uploaded using the gradle-hockeyapp-plugin"
     def String status = 2
     def String notify = 0

--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
@@ -64,7 +64,7 @@ class HockeyAppUploadTask extends DefaultTask {
     @TaskAction
     def upload() throws IOException {
 
-        if (!project.hockeyapp.apiToken) {
+        if (!getApiToken()) {
             throw new IllegalArgumentException("Cannot upload to HockeyApp because API Token is missing")
         }
 
@@ -142,7 +142,7 @@ class HockeyAppUploadTask extends DefaultTask {
         }
         decorateWithOptionalProperties(entityBuilder)
 
-        httpPost.addHeader("X-HockeyAppToken", project.hockeyapp.apiToken)
+        httpPost.addHeader("X-HockeyAppToken", getApiToken())
 
 
         int lastProgress = 0
@@ -256,6 +256,16 @@ class HockeyAppUploadTask extends DefaultTask {
         if (mandatory){
             entityBuilder.addPart("mandatory", new StringBody(mandatory))
         }
+    }
+
+    private String getApiToken() {
+        String apiToken = project.hockeyapp.apiToken
+        if (project.hockeyapp.variantToApiToken) {
+            if (project.hockeyapp.variantToApiToken[variantName]) {
+                apiToken = project.hockeyapp.variantToApiToken[variantName]
+            }
+        }
+        return apiToken
     }
 
     @Nullable


### PR DESCRIPTION
Would it be useful to be able to map variants to different api tokens?  I would like to upload different variants to separate instances of hockeyapp but the api token generation in hockeyapp only allows access to either one app or all apps.

So we could do something like this:

```
hockeyapp {
  ...
  variantToApiToken = [
    dev: <dev_api_token>
    release: <release_api_token>
  ]
  ...
}
```

I figured I would attempt to implement it myself instead of just asking for you to add the feature this time.
