### PR TITLE
Always resolving mapping file for application variant

### DIFF
--- a/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
+++ b/src/main/groovy/de/felixschulze/gradle/HockeyAppUploadTask.groovy
@@ -85,13 +85,7 @@ class HockeyAppUploadTask extends DefaultTask {
                 }
             }
 
-            if (applicationVariant.getObfuscation()) {
-                logger.debug('Obfuscation is used')
-                mappingFile = applicationVariant.getMappingFile()
-            } else {
-                logger.debug('Obfuscation is not used')
-                mappingFileCouldBePresent = false
-            }
+            mappingFile = applicationVariant.getMappingFile()
         }
         else {
             logger.debug('Not using android application variants')


### PR DESCRIPTION
When using DexGuard `applicationVariant.getObfuscation()` is `false` while the mapping file is still present.
This stops assuming there is no mapping file if `getObfuscation` is false and instead allows weather the
mapping file is present to determine if it should be uploaded.