### PR TITLE
Add sample upload task command to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ hockeyapp {
 }
 ```
 
+### Upload task
+The task name is generated based on your productFlavors and buildTypes. For a basic release build with no flavors using the gradle wrapper:
+```gradle
+./gradlew uploadReleaseToHockeyApp
+```
+
 ## Advanced usage
 
 Add to your build.gradle


### PR DESCRIPTION
The plugin does not provide information on the generated task name. Adding a sample to the Basic usage part will make it clearer.