### PR TITLE
[POC] Temporary fix for the latest Android Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'org.apache.httpcomponents:httpclient:4.5.1'
     compile 'org.apache.httpcomponents:httpmime:4.5.1'
-    compile 'com.android.tools.build:gradle:1.5.0'
+    compile 'com.android.tools.build:gradle:2.3.0'
     compile 'de.felixschulze.teamcity:teamcity-status-message-helper:1.2'
 
     testCompile 'junit:junit:4.12'

--- a/example/app/build.gradle
+++ b/example/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'de.felixschulze.gradle.hockeyapp'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.3"
+    compileSdkVersion 'android-O'
+    buildToolsVersion '26.0.0-rc2'
     defaultConfig {
         applicationId "de.felixschulze.android.example"
         minSdkVersion 21
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -25,7 +25,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:appcompat-v7:26.0.0-beta1'
     testCompile 'junit:junit:4.12'
 
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,11 +2,13 @@
 
 buildscript {
     repositories {
+        maven { url 'https://maven.google.com' }
         jcenter()
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
-        classpath 'de.felixschulze.gradle:gradle-hockeyapp-plugin:3.6'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha2'
+        classpath 'de.felixschulze.gradle:gradle-hockeyapp-plugin:3.7-SNAPSHOT'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,6 +18,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven { url 'https://maven.google.com' }
     }
 }
 

--- a/example/gradle/wrapper/gradle-wrapper.properties
+++ b/example/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Tue May 30 13:30:54 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 18 07:54:07 CEST 2016
+#Tue May 30 13:30:54 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip


### PR DESCRIPTION
## Changes 
In the latest Android Gradle plugin `BaseVariantOutput#getOutputs()` is no longer supported and there's not replacement for that API at the moment (see: https://developer.android.com/studio/preview/features/new-android-plugin-migration.html#variant_api)

This is a temporary fix, I'm not sure if it's working in every setup. 
Instead of getting the exact file path from the Android Gradle plugin, I'm searching for APKs in the build directory and try to match them with the variant name. 

I really don't recommend merging it. There'll be a replacement API, that's doing this properly. 

Fixes: https://github.com/x2on/gradle-hockeyapp-plugin/issues/101